### PR TITLE
update requirements for v0.19

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dulwich" %}
-{% set version = "0.18.6" %}
-{% set sha256 = "38a04406bc68315794c3bab37c7d4ed137fb8a839482d8894e72b0d9b3eb41a9" %}
+{% set version = "0.19.0" %}
+{% set sha256 = "91aad98f37a5494c6eabf08c78ed2b6e1b1ce6e7a5556406245d8763a352b99e" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dulwich" %}
-{% set version = "0.19.0" %}
-{% set sha256 = "91aad98f37a5494c6eabf08c78ed2b6e1b1ce6e7a5556406245d8763a352b99e" %}
+{% set version = "0.18.6" %}
+{% set sha256 = "38a04406bc68315794c3bab37c7d4ed137fb8a839482d8894e72b0d9b3eb41a9" %}
 
 package:
   name: {{ name|lower }}
@@ -20,8 +20,24 @@ requirements:
     - python
     - setuptools
     - toolchain
+    - urllib3
+    # secure
+    - pyopenssl >=0.14
+    - cryptography >=1.3.4
+    - idna >=2.0.0
+    - certifi
+    - ipaddress  # [py<=33]
+    - pysocks >=1.5.6,<2.0,!=1.5.7
   run:
     - python
+    - urllib3
+    # secure
+    - pyopenssl >=0.14
+    - cryptography >=1.3.4
+    - idna >=2.0.0
+    - certifi
+    - ipaddress  # [py<=33]
+    - pysocks >=1.5.6,<2.0,!=1.5.7
 
 test:
   imports:


### PR DESCRIPTION
* requires urllib3[secure]
* secure also requires certifi, ipaddress, idna, cryptography, and pyopenssl